### PR TITLE
Draw Functions Have CPUProfiler Traces

### DIFF
--- a/Plugins/NiagaraUIRenderer/Source/NiagaraUIRenderer/Private/NiagaraUIComponent.cpp
+++ b/Plugins/NiagaraUIRenderer/Source/NiagaraUIRenderer/Private/NiagaraUIComponent.cpp
@@ -80,6 +80,8 @@ struct FNiagaraRendererEntry
 
 void UNiagaraUIComponent::RenderUI(SNiagaraUISystemWidget* NiagaraWidget, float ScaleFactor, FVector2f ParentTopLeft, const FNiagaraWidgetProperties* WidgetProperties)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(UNiagaraUIComponent::RenderUI);
+
 	NiagaraWidget->ClearRenderData();
 
 	if (!IsActive())
@@ -160,6 +162,7 @@ FORCEINLINE FVector2D FastRotate(const FVector2D Vector, float Sin, float Cos)
 
 void UNiagaraUIComponent::AddSpriteRendererData(SNiagaraUISystemWidget* NiagaraWidget, TSharedRef<const FNiagaraEmitterInstance> EmitterInst, UNiagaraSpriteRendererProperties* SpriteRenderer, float ScaleFactor, FVector2f ParentTopLeft, const FNiagaraWidgetProperties* WidgetProperties)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(UNiagaraUIComponent::AddSpriteRendererData);
 	SCOPE_CYCLE_COUNTER(STAT_GenerateSpriteData);
 	FVector ComponentLocation = GetRelativeLocation();
 	FVector ComponentScale = GetRelativeScale3D();
@@ -374,6 +377,7 @@ void UNiagaraUIComponent::AddSpriteRendererData(SNiagaraUISystemWidget* NiagaraW
 
 void UNiagaraUIComponent::AddRibbonRendererData(SNiagaraUISystemWidget* NiagaraWidget, TSharedRef<const FNiagaraEmitterInstance> EmitterInst, UNiagaraRibbonRendererProperties* RibbonRenderer, float ScaleFactor, FVector2f ParentTopLeft, const FNiagaraWidgetProperties* WidgetProperties)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(UNiagaraUIComponent::AddRibbonRendererData);
 	SCOPE_CYCLE_COUNTER(STAT_GenerateRibbonData);
 	
 	FVector ComponentLocation = GetRelativeLocation();

--- a/Plugins/NiagaraUIRenderer/Source/NiagaraUIRenderer/Private/SNiagaraUISystemWidget.cpp
+++ b/Plugins/NiagaraUIRenderer/Source/NiagaraUIRenderer/Private/SNiagaraUISystemWidget.cpp
@@ -20,6 +20,8 @@ SNiagaraUISystemWidget::~SNiagaraUISystemWidget()
 
 int32 SNiagaraUISystemWidget::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(SNiagaraUISystemWidget::OnPaint);
+
     if (!NiagaraComponent.IsValid())
         return LayerId;
 


### PR DESCRIPTION
- RenderUI, AddSpriteRendererData, AddRibbonRendererData, and OnPaint functions have TRACE_CPUPROFILER_EVENT_SCOPE added to measure performance in Unreal Insights