### PR TITLE
Prevent crash when trying to initialize Niagara System during world teardown

### DIFF
--- a/Plugins/NiagaraUIRenderer/Source/NiagaraUIRenderer/Private/NiagaraSystemWidget.cpp
+++ b/Plugins/NiagaraUIRenderer/Source/NiagaraUIRenderer/Private/NiagaraSystemWidget.cpp
@@ -80,6 +80,9 @@ void UNiagaraSystemWidget::InitializeNiagaraUI()
 {
 	if (UWorld* World = GetWorld())
 	{
+		if(World->bIsTearingDown)
+			return;
+		
 		if (!World->PersistentLevel)
 			return;
 


### PR DESCRIPTION
had this crash happen in my setup. The fix is easy and short, would be nice if this got merged into the main branch