### PR TITLE
Add Mac/Linux/Android/IOS entries into SupportedTargetPlatforms and PlatformAllowList's

### DIFF
--- a/Plugins/NiagaraUIRenderer/NiagaraUIRenderer.uplugin
+++ b/Plugins/NiagaraUIRenderer/NiagaraUIRenderer.uplugin
@@ -17,7 +17,10 @@
 	"Installed": false,
 	"SupportedTargetPlatforms": [
 		"Win64",
-		"Android"
+		"Mac",
+		"Linux",
+		"Android",
+		"IOS"
 	],
 	"Modules": [
 		{
@@ -26,7 +29,10 @@
 			"LoadingPhase": "PreDefault",
 			"PlatformAllowList": [
 				"Win64",
-				"Android"
+				"Mac",
+				"Linux",
+				"Android",
+				"IOS"
 			]
 		},
 		{
@@ -34,7 +40,9 @@
 			"Type": "Editor",
 			"LoadingPhase": "Default",
 			"PlatformAllowList": [
-				"Win64"
+				"Win64",
+				"Mac",
+				"Linux"
 			]
 		}
 	],


### PR DESCRIPTION
It is more than reasonable to not support platforms you do not have access to! However the plugin does currently seem to work fine on these platforms, so I don't think there is harm in adding them to the platform whitelist, so that their use isn't intrinsically blocked?

You still do not need to provide support for those platforms, can be considered "at users own risk" :)

Thanks for the useful tool!